### PR TITLE
샘플 코드 업데이트 (stb-iptv-singleplayer-sample, stb-iptv-dualplayer-sample)

### DIFF
--- a/stb-iptv-dualplayer-sample/src/main/java/tv/anypoint/lineartv/sample/AdsManagerListenerImpl.java
+++ b/stb-iptv-dualplayer-sample/src/main/java/tv/anypoint/lineartv/sample/AdsManagerListenerImpl.java
@@ -1,11 +1,15 @@
 package tv.anypoint.lineartv.sample;
 
+import android.view.View;
+import com.google.android.exoplayer2.ui.PlayerView;
 import tv.anypoint.api.ads.AnypointAdsManager;
 
 class AdsManagerListenerImpl implements AnypointAdsManager.AdsManagerListener {
     private final ChannelPlayer channelPlayer;
-    public AdsManagerListenerImpl(ChannelPlayer channelPlayer) {
+    private final PlayerView adPlayerView;
+    public AdsManagerListenerImpl(ChannelPlayer channelPlayer, PlayerView adPlayerView) {
         this.channelPlayer = channelPlayer;
+        this.adPlayerView = adPlayerView;
     }
 
     @Override
@@ -15,6 +19,7 @@ class AdsManagerListenerImpl implements AnypointAdsManager.AdsManagerListener {
 
     public void onPlay(boolean retainChannelStream) {
         channelPlayer.setVolume(0);
+        adPlayerView.setVisibility(View.VISIBLE);
     }
 
     @Override
@@ -34,6 +39,7 @@ class AdsManagerListenerImpl implements AnypointAdsManager.AdsManagerListener {
 
     public void onStopped(boolean retainChannelStream) {
         channelPlayer.setVolume(1);
+        adPlayerView.setVisibility(View.GONE);
     }
 
     @Override

--- a/stb-iptv-dualplayer-sample/src/main/java/tv/anypoint/lineartv/sample/ChannelPlayer.java
+++ b/stb-iptv-dualplayer-sample/src/main/java/tv/anypoint/lineartv/sample/ChannelPlayer.java
@@ -21,8 +21,6 @@ public class ChannelPlayer implements Player.Listener {
                         Util.getUserAgent(context, "ChannelPlayer")
                 );
 
-        DefaultRenderersFactory renderersFactory = new DefaultRenderersFactory(context);
-
         player = channelPlayer;
     }
 

--- a/stb-iptv-dualplayer-sample/src/main/java/tv/anypoint/lineartv/sample/MainActivity.java
+++ b/stb-iptv-dualplayer-sample/src/main/java/tv/anypoint/lineartv/sample/MainActivity.java
@@ -38,11 +38,12 @@ public class MainActivity extends Activity {
         AnypointAdView adView = findViewById(R.id.linearTvAdView);
 
         // Register your custom player to the AnypointAdView.
-        CustomAdPlayer customAdPlayer = new CustomAdPlayer();
+        PlayerView adPlayerView = findViewById(R.id.adPlayer);
+        CustomAdPlayer customAdPlayer = new CustomAdPlayer(this, adPlayerView);
         adView.setAdPlayer(customAdPlayer);
 
-        AnypointAdsManager adsManager = adView.getAnypointAdsManager();
-        AnypointAdsManager.AdsManagerListener adsManagerListener = new AdsManagerListenerImpl(channelPlayer);
+        adsManager = adView.getAnypointAdsManager();
+        AnypointAdsManager.AdsManagerListener adsManagerListener = new AdsManagerListenerImpl(channelPlayer, adPlayerView);
 
         adsManager.addListener(adsManagerListener);
 

--- a/stb-iptv-dualplayer-sample/src/main/res/layout/activity_main.xml
+++ b/stb-iptv-dualplayer-sample/src/main/res/layout/activity_main.xml
@@ -21,4 +21,13 @@
             android:layout_height="match_parent"
     />
 
+    <com.google.android.exoplayer2.ui.PlayerView
+            android:id="@+id/adPlayer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_centerInParent="true"
+            app:use_controller="false"
+            android:visibility="gone"
+    />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stb-iptv-singleplayer-sample/src/main/java/tv/anypoint/lineartv/sample/AdsManagerListenerImpl.java
+++ b/stb-iptv-singleplayer-sample/src/main/java/tv/anypoint/lineartv/sample/AdsManagerListenerImpl.java
@@ -14,8 +14,6 @@ class AdsManagerListenerImpl implements AnypointAdsManager.AdsManagerListener {
     }
 
     public void onPlay(boolean retainChannelStream) {
-        // TODO: stop LinearTV and play ad
-        channelPlayer.play();
     }
 
     @Override
@@ -34,8 +32,6 @@ class AdsManagerListenerImpl implements AnypointAdsManager.AdsManagerListener {
     }
 
     public void onStopped(boolean retainChannelStream) {
-        // ads stopped and play LinearTV
-        channelPlayer.playChannel();
     }
 
     @Override

--- a/stb-iptv-singleplayer-sample/src/main/java/tv/anypoint/lineartv/sample/MainActivity.java
+++ b/stb-iptv-singleplayer-sample/src/main/java/tv/anypoint/lineartv/sample/MainActivity.java
@@ -40,7 +40,7 @@ public class MainActivity extends Activity {
         // Register your custom player to the AnypointAdView.
         adView.setAdPlayer(channelPlayer);
 
-        AnypointAdsManager adsManager = adView.getAnypointAdsManager();
+        adsManager = adView.getAnypointAdsManager();
         AnypointAdsManager.AdsManagerListener adsManagerListener = new AdsManagerListenerImpl(channelPlayer);
 
         adsManager.addListener(adsManagerListener);


### PR DESCRIPTION
#### dualPlayer
* PlayerView가 2개 배치된 예시로 변경했습니다.
* `CustomAdPlayer` 생성자에 구현된 예시를 작성했습니다.

#### singlePlayer
* `AnypointAdsManager.AdsManagerListener`의 동작을 모두 뻈습니다. `ChannelPlayerWithAd`가 채널 동작까지 수행하기 때문입니다.
* release 코드가 아무런 수행을 하지 않도록 변경합니다. channel player를 겸용하기 때문입니다.

#### 공통
* `load(..)`에 구현된 예시를 작성했습니다.
* 일부 구현 되지 않은 코드를 구현했습니다. (resume, pause, isAdPlaying, currentMediaUrl)
